### PR TITLE
Expand agent_endpoint_integration tests to include Agent persistence and more

### DIFF
--- a/e2e/_suites/ingest-manager/features/agent_endpoint_integration.feature
+++ b/e2e/_suites/ingest-manager/features/agent_endpoint_integration.feature
@@ -36,3 +36,34 @@ Scenario: Removing Endpoint from Agent policy stops the connected Endpoint
   Then the agent is listed in Fleet as "online"
     But the host name is not shown in the Administration view in the Security App
     And the "elastic-endpoint" process is in the "stopped" state on the host
+
+@stop-agent-and-endpoint
+Scenario Outline: Stopping the agent deployed with Endpoint stops all backend processes
+  Given an Endpoint is successfully deployed with a "centos" Agent
+  When the "elastic-agent" process is "stopped" on the host
+  Then the "elastic-endpoint" process is in the "stopped" state on the host
+
+@restart-host-with-endpoint-deployed
+Scenario Outline: Restarting the host with persistent agent with Endpoint restarts backend processes
+  Given an Endpoint is successfully deployed with a "centos" Agent
+  When the host is restarted
+  Then the "elastic-agent" process is in the "started" state on the host
+    And the "elastic-endpoint" process is in the "started" state on the host
+
+@unenroll-with-deployed-endpoint
+Scenario Outline: Un-enrolling the agent with Endpoint
+  Given an Endpoint is successfully deployed with a "centos" Agent
+  When the agent is un-enrolled
+  Then the "elastic-agent" process is in the "started" state on the host
+    And the agent is listed in Fleet as "inactive"
+    And the "elastic-endpoint" process is in the "stopped" state on the host
+
+@reenroll-with-deployed-endpoint
+Scenario Outline: Re-enrolling the agent with Endpoint
+  Given an Endpoint is successfully deployed with a "centos" Agent
+    And the agent is un-enrolled
+    And the "elastic-agent" process is "stopped" on the host
+  When the agent is re-enrolled on the host
+    And the "elastic-agent" process is "started" on the host
+  Then the agent is listed in Fleet as "online"
+    And the "elastic-endpoint" process is in the "started" state on the host


### PR DESCRIPTION
Feature test work for Agent & Endpoint integration
In support of https://github.com/elastic/e2e-testing/issues/336

## What does this PR do?

This PR re-uses existing steps from the Agent side and includes tests written there to include when Endpoint is deployed (included in Policy) to ensure Endpoint behaves as expected as well.

It does not include any new implementation, so that is neat - its the first time we have enough 'building blocks' to re-use feature file code and extend its reach without having to write more support code.

## Why is it important?
This is key as Agent controls Endpoint start, stop, deploy, and communication - and we found a bug recently that could have been caught if we had these tests (that we were planning on doing anyhow).

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run the Unit tests for the CLI, and they are passing locally
- [ ] I have run the End-2-End tests for the suite I'm working on, and they are passing locally
- [ ] I have noticed new Go dependencies (run `make notice` in the proper directory)
